### PR TITLE
Fix code style issue

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -478,7 +478,7 @@ Parser.prototype._addReadLength = function (writeFunc, length, readVal, allowLes
     checkValue(cb.length, 3)
     const len = length(obj)
 
-    read(len, function processReadLength(buf, offset, done) {
+    read(len, function processReadLength (buf, offset, done) {
       if (!allowLess && done) {
         cb(read, null, done)
       } else {
@@ -496,7 +496,7 @@ Parser.prototype._addReadFunc = function (nextFunc) {
   checkValue(readFunc.length, 3)
 
   this.readFunc = function callPrev (read, obj, cb) {
-    readFunc(read, obj, function executedPrev(read, obj, done) {
+    readFunc(read, obj, function executedPrev (read, obj, done) {
       if (done) cb(read, null, true)
       else nextFunc(read, obj, cb)
     })


### PR DESCRIPTION
With this fix the 'JavaScript Standard Style' check will pass 
when running ```npm test```

Error before this fix was:
```bash
> standard index.js lib/*.js

standard: Use JavaScript Standard Style (http://standardjs.com)
standard: Run `standard --fix` to automatically fix some problems.
  binopsy/lib/parser.js:481:41: Missing space before function parentheses.
  binopsy/lib/parser.js:499:46: Missing space before function parentheses.
```