### PR TITLE
Add test to check long bitfields

### DIFF
--- a/test/primitive_parser.js
+++ b/test/primitive_parser.js
@@ -217,6 +217,23 @@ describe('Primitive parser', function(){
                 e: 1
             }, cb);
         });
+        it('should parse 6-byte-length bit field sequence', function(done) {
+            var cb = getCb(2, done)
+
+            var parser = new Parser()
+                .bit48('a');
+            var buf = binaryLiteral('111111111111111111111111111111111111111111111111');
+            checkResult(parser, buf, {
+                a: 281474976710655
+            }, cb);
+
+            parser = new Parser()
+                .endianess('little')
+                .bit1('a');
+            checkResult(parser, buf, {
+                a: 281474976710655
+            }, cb);
+        });
         it('should parse nested bit fields', function(done) {
             var parser = new Parser()
                 .bit1('a')

--- a/test/primitive_parser.js
+++ b/test/primitive_parser.js
@@ -229,7 +229,7 @@ describe('Primitive parser', function(){
 
             parser = new Parser()
                 .endianess('little')
-                .bit1('a');
+                .bit48('a');
             checkResult(parser, buf, {
                 a: 281474976710655
             }, cb);


### PR DESCRIPTION
Javascript supports safe integer representation up to 53 bits.
Keeping byte alignment it should be possible to support bitfields of 6 bytes.
Note: Bitwise operators in Javascript do only work with 32 bits,
but it should be possible to support longer bitfields if using decimal arithmetic instead.